### PR TITLE
Fix SRV_ADR typo and README.md references

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,2 +1,2 @@
 SERVER_KEY=
-SVR_ADR=https://runtime.fivem.net/artifacts/fivem/build_proot_linux/master/
+SRV_ADR=https://runtime.fivem.net/artifacts/fivem/build_proot_linux/master/

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ connect fivem.gruber.dev.br
 ```sh
 git clone https://github.com/gruberdev/infrastructure-fivem.git
 cd infrastructure-fivem
-# Remember to insert your server token into .env.example
-cp .env.example .env
+# Remember to insert your server token into .example.env
+cp .example.env .env
 docker-compose up --build -d
 ```
 


### PR DESCRIPTION
## Summary:
* In README.md change .env.example to .example.env.
* Change SVR_ADR to SRV_ADR in .example.env

## Description:
The README.md referenced a file that didn't exist, .env.example.
Docker failed to execute a script be wget wasn't provided a URL, after following the example environment provided. This failed because the script was looking for SRV_ADR but the environment file used SVR_ADR as the key.